### PR TITLE
Increase TTL of TXT records to 3600

### DIFF
--- a/certbot_dns_desec/dns_desec.py
+++ b/certbot_dns_desec/dns_desec.py
@@ -21,7 +21,7 @@ class Authenticator(dns_common.DNSAuthenticator):
     """
 
     description = "Obtain certificates using a DNS TXT record (if you are using deSEC.io for DNS)."
-    ttl = 60
+    ttl = 3600
     DEFAULT_ENDPOINT = "https://desec.io/api/v1/"
 
     def __init__(self, *args, **kwargs):


### PR DESCRIPTION
For LE, the TTL does not matter, as they speak to the authoritative
NS directly. However, desec-stack by default assigns minimum TTL of
3600 to domains, which breaks this plugin for such domains.