### PR TITLE
Throttle API requests to deSEC according to their limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ To acquire a single certificate for both ``example.com`` and ``*.example.com``:
 
 ## Development and Testing
 
-To test this, install the virtual environment (venv) for this repository and activate it.
+To test certbot-dns-desec, create a virtual environment at `venv/` for this repository and activate it.
 Register a domain `$DOMAIN` with desec.io, and obtain a DNS management token `$TOKEN`. Then run
 
     python3 -m pip install .
@@ -86,7 +86,7 @@ Register a domain `$DOMAIN` with desec.io, and obtain a DNS management token `$T
     EMAIL=youremail@example.com
     echo "dns_desec_token = $TOKEN" > desec-secret.ini
     chmod 600 desec-secret.ini
-    certbot \
+    ./venv/bin/certbot \
         --config-dir tmp/certbot/config \
         --logs-dir tmp/certbot/logs \
         --work-dir tmp/certbot/work \

--- a/certbot_dns_desec/dns_desec.py
+++ b/certbot_dns_desec/dns_desec.py
@@ -30,7 +30,7 @@ class Authenticator(dns_common.DNSAuthenticator):
     @classmethod
     def add_parser_arguments(cls, add):  # pylint: disable=arguments-differ
         super(Authenticator, cls).add_parser_arguments(
-            add, default_propagation_seconds=5  # TODO
+            add, default_propagation_seconds=65  # TODO decrease after deSEC fixed their NOTIFY problem
         )
         add("credentials", help="deSEC credentials INI file.")
 

--- a/certbot_dns_desec/dns_desec.py
+++ b/certbot_dns_desec/dns_desec.py
@@ -21,7 +21,7 @@ class Authenticator(dns_common.DNSAuthenticator):
     """
 
     description = "Obtain certificates using a DNS TXT record (if you are using deSEC.io for DNS)."
-    DEFAULT_ENDPOINT = "https://desec.io/api/v1/"
+    DEFAULT_ENDPOINT = "https://desec.io/api/v1"
 
     def __init__(self, *args, **kwargs):
         super(Authenticator, self).__init__(*args, **kwargs)
@@ -80,7 +80,7 @@ class _DesecConfigClient(object):
 
     def __init__(self, endpoint, token):
         logger.debug("creating _DesecConfigClient")
-        self.endpoint = endpoint
+        self.endpoint = endpoint.rstrip('/')
         self.token = token
         self.session = requests.Session()
         self.session.headers["Authorization"] = f"Token {token}"
@@ -98,7 +98,7 @@ class _DesecConfigClient(object):
     def get_txt_rrset(self, zone, subname):
         domain = zone['name']
         response = self.session.get(
-            url=f"{self.endpoint}/domains/{domain}/rrsets/{subname}/TXT",
+            url=f"{self.endpoint}/domains/{domain}/rrsets/{subname}/TXT/",
         )
 
         if response.status_code == 404:

--- a/certbot_dns_desec/dns_desec_test.py
+++ b/certbot_dns_desec/dns_desec_test.py
@@ -47,7 +47,7 @@ class AuthenticatorTest(
         # _get_desec_client | pylint: disable=protected-access
         self.auth._get_desec_client = mock.MagicMock(return_value=self.mock_client)
 
-    @test_util.patch_get_utility()
+    @test_util.patch_display_util()
     def test_perform(self, unused_mock_get_utility):
         self.auth.perform([self.achall])
 


### PR DESCRIPTION
Currently, certificates with many domain names can't be obtained as deSEC does not accept a sufficient large burst of requests. Bundling requests on the plugin side seems troublesome as the plugin API is called for one name at a time.

The limits will need manual updating when they change upstream at desec-io/desec-stack.

Other changes:

- README clarifications
- Increase in propagation time (I've witnessed that 5s weren't sufficient)
- Adjust URL to avoid double-slahes ('//') which cause 301 replies by the deSEC API
