### PR TITLE
Prepare First Release

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,12 @@
+# These are supported funding model platforms
+
+github: [desec-io] # Replace with up to 4 GitHub Sponsors-enabled usernames e.g., [user1, user2]
+patreon: # Replace with a single Patreon username
+open_collective: # Replace with a single Open Collective username
+ko_fi: # Replace with a single Ko-fi username
+tidelift: # Replace with a single Tidelift platform-name/package-name e.g., npm/babel
+community_bridge: # Replace with a single Community Bridge project-name e.g., cloud-foundry
+liberapay: deSEC
+issuehunt: # Replace with a single IssueHunt username
+otechie: # Replace with a single Otechie username
+custom: ['https://desec.io/donate']

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ It accepts the following command line arguments:
 
 1. ``--dns-desec-credentials <file>`` Specifies the file holding the deSEC API credentials (required, see below).
 1. ``--dns-desec-propagation-seconds`` Waiting time for DNS to propagate before asking the ACME server to verify the
-    DNS record (default 65).
+    DNS record (default 80).
 
 
 ## Credentials File Format

--- a/README.md
+++ b/README.md
@@ -19,11 +19,12 @@ python3 -m pip install certbot certbot-dns-desec
 ## Prerequisites
 
 To get a Let's Encrypt certificate for your domain `$DOMAIN`,
-you need an access token `$TOKEN` for the deSEC.io account that holds the domain you need the certificate for.
-Also make sure that your domain name has been delegated to deSEC according to deSEC's instructions.
+you need a deSEC API token `$TOKEN` with sufficient permission for performing the required DNS changes on your domain.
+Also make sure that your domain name has been delegated to deSEC
+(in other words: make sure that the parent registry has the right NS records).
 
 
-## Issue Certificate
+## Request Certificate
 
 To issue and renew certificates using `certbot-dns-desec`, an access token to your deSEC account is required.
 To store such a token in a secure location, use, e.g.:
@@ -40,7 +41,7 @@ sudo chmod 600 /etc/letsencrypt/.secrets/$DOMAIN.ini
 Adjust `$DOMAIN` and `$TOKEN` according to your domain and deSEC access token, respectively.
 The file location is just a suggestion and can be changed.
 
-With the credentials stored, you can apply for a wildcard certificate for your domain by using, e.g.,
+With the credentials stored, you can request a wildcard certificate for your domain by using, e.g.,
 
 ```shell
 certbot certonly \
@@ -52,8 +53,9 @@ certbot certonly \
 
 In this command, `--authenticator dns-desec` activates the `certbot-dns-desec` plugin;
 the `--dns-desec-credentials` argument provides the deSEC access token location to the plugin.
-These flags can be combined with more sophisticated usages of certbot, e.g. to automatically reload servers after the
-renewal process.
+These flags can be combined with more sophisticated usages of certbot,
+e.g. to automatically reload servers after the renewal process.
+Such functionality is independent of this plugin; for details, see the certbot documentation.
 
 
 ## CLI Interface
@@ -63,7 +65,7 @@ It accepts the following command line arguments:
 
 1. ``--dns-desec-credentials <file>`` Specifies the file holding the deSEC API credentials (required, see below).
 1. ``--dns-desec-propagation-seconds`` Waiting time for DNS to propagate before asking the ACME server to verify the
-    DNS record (default 80).
+    DNS record.
 
 
 ## Credentials File Format

--- a/README.md
+++ b/README.md
@@ -23,6 +23,12 @@ you need a deSEC API token `$TOKEN` with sufficient permission for performing th
 Also make sure that your domain name has been delegated to deSEC
 (in other words: make sure that the parent registry has the right NS records).
 
+If you don't have a token yet, an easy way to obtain one it by logging into your account at [deSEC.io](//desec.io),
+navigate to "Token Management" and create a new one.
+It's good practice to restrict the token permissions as much as possible,
+e.g. by setting the maximum unused period to four months.
+This way, the token will expire if it is not continuously used to renew your certificate.
+Tokens can also be created [using the deSEC API](//desec.readthedocs.io/en/latest/auth/tokens.html#creating-a-token).
 
 ## Request Certificate
 

--- a/README.md
+++ b/README.md
@@ -23,12 +23,14 @@ you need a deSEC API token `$TOKEN` with sufficient permission for performing th
 Also make sure that your domain name has been delegated to deSEC
 (in other words: make sure that the parent registry has the right NS records).
 
-If you don't have a token yet, an easy way to obtain one it by logging into your account at [deSEC.io](//desec.io),
-navigate to "Token Management" and create a new one.
+If you don't have a token yet, an easy way to obtain one is by logging into your account at
+[deSEC.io](https://desec.io).
+Navigate to "Token Management" and create a new one.
 It's good practice to restrict the token permissions as much as possible,
 e.g. by setting the maximum unused period to four months.
 This way, the token will expire if it is not continuously used to renew your certificate.
-Tokens can also be created [using the deSEC API](//desec.readthedocs.io/en/latest/auth/tokens.html#creating-a-token).
+Tokens can also be created
+[using the deSEC API](https://desec.readthedocs.io/en/latest/auth/tokens.html#creating-a-token).
 
 ## Request Certificate
 

--- a/README.md
+++ b/README.md
@@ -68,12 +68,9 @@ It accepts the following command line arguments:
 
 ## Credentials File Format
 
-An example ``credentials.ini`` file:
+The credentials file only holds the deSEC API access token:
 
     dns_desec_token = token
-
-Additionally, the URL of the deSEC API can be specified using the `dns_desec_endpoint` configuration option.
-`https://desec.io/api/v1/` is the default.
 
 
 ## Development and Testing

--- a/README.md
+++ b/README.md
@@ -12,14 +12,14 @@ challenge mechanism.
 To get certificates from Let's Encrypt, install certbot and this plugin.
 There are many ways to install certbot, this guide uses Python's `pip`:
 
-```
+```shell
 python3 -m pip install certbot certbot-dns-desec
 ```
 
 ## Prerequisites
 
-To get a Let's Encrypt certificate for your domain,
-you need an access token for the deSEC.io account that holds the domain you need the certificate for.
+To get a Let's Encrypt certificate for your domain `$DOMAIN`,
+you need an access token `$TOKEN` for the deSEC.io account that holds the domain you need the certificate for.
 Also make sure that your domain name has been delegated to deSEC according to deSEC's instructions.
 
 
@@ -28,7 +28,7 @@ Also make sure that your domain name has been delegated to deSEC according to de
 To issue and renew certificates using `certbot-dns-desec`, an access token to your deSEC account is required.
 To store such a token in a secure location, use, e.g.:
 
-```
+```shell
 DOMAIN=example.com
 TOKEN=your-desec-access-token
 sudo mkdir /etc/letsencrypt/secrets/
@@ -42,7 +42,7 @@ The file location is just a suggestion and can be changed.
 
 With the credentials stored, you can apply for a wildcard certificate for your domain by using, e.g.,
 
-```
+```shell
 certbot certonly \
      --authenticator dns-desec \
      --dns-desec-credentials /etc/letsencrypt/secrets/$DOMAIN.ini \
@@ -78,7 +78,7 @@ The credentials file only holds the deSEC API access token:
 To test certbot-dns-desec, create a virtual environment at `venv/` for this repository and activate it.
 Register a domain `$DOMAIN` with desec.io, and obtain a DNS management token `$TOKEN`. Then run
 
-```
+```shell
 python3 -m pip install .
 TOKEN=token-you-obtained-from-desec-io
 DOMAIN=domain-you-registered-at-desec-io

--- a/certbot_dns_desec/dns_desec.py
+++ b/certbot_dns_desec/dns_desec.py
@@ -31,7 +31,7 @@ class Authenticator(dns_common.DNSAuthenticator):
     @classmethod
     def add_parser_arguments(cls, add):  # pylint: disable=arguments-differ
         super(Authenticator, cls).add_parser_arguments(
-            add, default_propagation_seconds=65  # TODO decrease after deSEC fixed their NOTIFY problem
+            add, default_propagation_seconds=80  # TODO decrease after deSEC fixed their NOTIFY problem
         )
         add("credentials", help="deSEC credentials INI file.")
 

--- a/certbot_dns_desec/dns_desec.py
+++ b/certbot_dns_desec/dns_desec.py
@@ -46,7 +46,7 @@ class Authenticator(dns_common.DNSAuthenticator):
             "credentials",
             "deSEC credentials INI file",
             {
-                # "endpoint": "URL of the deSEC API.", # TODO add documentation for this
+                # "endpoint": "URL of the deSEC API.", # TODO add support for different endpoints
                 "token": "Access token for deSEC API.",
             },
         )

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup
 from setuptools import find_packages
 
-version = "0.3.0"
+version = "1.0.0"
 
 install_requires = [
     "acme>=0.29.0",


### PR DESCRIPTION
This overhauls the README.

Please that need adjustment for release of `certbot-dns-desec` that are not part of this repository are:

- [ ] [deSEC Docs](https://desec.readthedocs.io/en/latest/dyndns/lets-encrypt.html)
      see desec-io/desec-stack#588
- [ ] [the old hook script](https://github.com/desec-io/desec-certbot-hook)
      see desec-io/desec-certbot-hook#20
- [ ] maybe [Tools implementing deSEC](https://talk.desec.io/t/tools-implementing-desec/11)
- [ ] some talk.desec.io threads: [one](https://talk.desec.io/t/failing-to-get-letsencrypt-hook-to-desec/344/4), [two](https://talk.desec.io/t/certbot-dns-plugin/174), [three](https://talk.desec.io/t/failed-during-certbot-renew/250). (I don't really like resurrecting old threads, but these are quite popular on on-topic Google searches, so in this case, it might be justified.)
- [ ] notify #10 about release and see if issue comes up again

Please feel free to extend the list and to amend this PR with changes to README.