### PR TITLE
Challenge Cleanup and Nits

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,9 +78,12 @@ It accepts the following command line arguments:
 
 ## Credentials File Format
 
-The credentials file only holds the deSEC API access token:
+An example ``credentials.ini`` file:
 
     dns_desec_token = token
+
+Additionally, the URL of the deSEC API can be specified using the `dns_desec_endpoint` configuration option.
+`https://desec.io/api/v1/` is the default.
 
 
 ## Development and Testing

--- a/certbot_dns_desec/dns_desec.py
+++ b/certbot_dns_desec/dns_desec.py
@@ -4,17 +4,13 @@ import logging
 import time
 
 import requests
-import zope.interface
 from certbot import errors
-from certbot import interfaces
 from certbot.plugins import dns_common
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)
 
 
-@zope.interface.implementer(interfaces.IAuthenticator)
-@zope.interface.provider(interfaces.IPluginFactory)
 class Authenticator(dns_common.DNSAuthenticator):
     """DNS Authenticator for deSEC
 

--- a/certbot_dns_desec/dns_desec.py
+++ b/certbot_dns_desec/dns_desec.py
@@ -46,7 +46,7 @@ class Authenticator(dns_common.DNSAuthenticator):
             "credentials",
             "deSEC credentials INI file",
             {
-                # "endpoint": "URL of the deSEC API.", # TODO add support for different endpoints
+                "endpoint": "URL of the deSEC API.",
                 "token": "Access token for deSEC API.",
             },
         )

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup
 from setuptools import find_packages
 
-version = "1.0.0"
+version = "1.1.0"
 
 install_requires = [
     "acme>=0.29.0",


### PR DESCRIPTION
The main purpose of this PR is to fix the TXT record removal after the challenge protocol. Version 1.0.0 of certbot-dns-desec does not remove TXT records correctly. The reason for this is that, as deSEC API does not provide RR access, certbot-dns-desec retrieves a list of current TXT records and needs to remove the challenge TXT record from the obtained set, to then update the entire RRset using deSEC API. However, instead of removing the challenge from the obtained RRset, certbot-dns-desec computed the *intersection* of the obtained RRset and the set just containing the challenge, effectively removing everything but the challenge. (If the TXT RRset only contains the challenge, as is mostly the case, this is effectively no-op.)

This PR fixes this behavior and adds tests that would have caught the bug.

Also, this PR re-adds the endpoint docs to the README and removes some unused legacy code/symbols. 

Fixes #10 