### PR TITLE
Fix 1.3.1 builds without network (for Debian)

### DIFF
--- a/certbot_dns_desec/dns_desec.py
+++ b/certbot_dns_desec/dns_desec.py
@@ -71,7 +71,7 @@ class Authenticator(dns_common.DNSAuthenticator):
             for _ in range(7):
                 validation_name = dns.resolver.resolve(validation_name, 'CNAME')[0].target
                 logger.debug(f"CNAME lookup result: {validation_name}")
-        except (dns.resolver.NXDOMAIN, dns.resolver.NoAnswer):
+        except (dns.resolver.NXDOMAIN, dns.resolver.NoAnswer, dns.resolver.NoResolverConfiguration):
             pass
         if isinstance(validation_name, dns.name.Name):
             validation_name = validation_name.to_text().rstrip('.')


### PR DESCRIPTION
Debian builds require a build in a network-less environment.

Without this patch, the build fails with the following error (when running the tests):
```
…
dh_auto_test -- --test-pytest
I: pybuild base:311: cd /build/python-certbot-dns-desec-1.3.2/.pybuild/cpython3_3.13_certbot-dns-desec/build; python3.13 -m pytest 
=============================================================================================== test session starts ===============================================================================================
platform linux -- Python 3.13.7, pytest-8.4.2, pluggy-1.6.0
rootdir: /build/python-certbot-dns-desec-1.3.2
plugins: typeguard-4.4.4, requests_mock-1.12.1
collected 12 items                                                                                                                                                                                                

certbot_dns_desec/dns_desec_test.py F...F.......                                                                                                                                                            [100%]

==================================================================================================== FAILURES =====================================================================================================
_________________________________________________________________________________________ AuthenticatorTest.test_cleanup __________________________________________________________________________________________

self = <certbot_dns_desec.dns_desec_test.AuthenticatorTest testMethod=test_cleanup>

    def test_cleanup(self):
        # _attempt_cleanup | pylint: disable=protected-access
        self.auth._attempt_cleanup = True
>       self.auth.cleanup([self.achall])

certbot_dns_desec/dns_desec_test.py:65: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
/usr/lib/python3/dist-packages/certbot/plugins/dns_common.py:99: in cleanup
    self._cleanup(domain, validation_domain_name, validation)
certbot_dns_desec/dns_desec.py:92: in _cleanup
    self._desec_work(domain, validation_name, validation, set.difference)
certbot_dns_desec/dns_desec.py:72: in _desec_work
    validation_name = dns.resolver.resolve(validation_name, 'CNAME')[0].target
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
/usr/lib/python3/dist-packages/dns/resolver.py:1564: in resolve
    return get_default_resolver().resolve(
           ^^^^^^^^^^^^^^^^^^^^^^
/usr/lib/python3/dist-packages/dns/resolver.py:1528: in get_default_resolver
    reset_default_resolver()
/usr/lib/python3/dist-packages/dns/resolver.py:1541: in reset_default_resolver
    default_resolver = Resolver()
                       ^^^^^^^^^^
/usr/lib/python3/dist-packages/dns/resolver.py:945: in __init__
    self.read_resolv_conf(filename)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <dns.resolver.Resolver object at 0x7fa8ea8338c0>, f = <_io.TextIOWrapper name='/etc/resolv.conf' mode='r' encoding='utf-8'>

    def read_resolv_conf(self, f: Any) -> None:
        """Process *f* as a file in the /etc/resolv.conf format.  If f is
        a ``str``, it is used as the name of the file to open; otherwise it
        is treated as the file itself.
    
        Interprets the following items:
    
        - nameserver - name server IP address
    
        - domain - local domain name
    
        - search - search list for host-name lookup
    
        - options - supported options are rotate, timeout, edns0, and ndots
    
        """
    
        nameservers = []
        if isinstance(f, str):
            try:
                cm: contextlib.AbstractContextManager = open(f)
            except OSError:
                # /etc/resolv.conf doesn't exist, can't be read, etc.
                raise NoResolverConfiguration(f"cannot open {f}")
        else:
            cm = contextlib.nullcontext(f)
        with cm as f:
            for l in f:
                if len(l) == 0 or l[0] == "#" or l[0] == ";":
                    continue
                tokens = l.split()
    
                # Any line containing less than 2 tokens is malformed
                if len(tokens) < 2:
                    continue
    
                if tokens[0] == "nameserver":
                    nameservers.append(tokens[1])
                elif tokens[0] == "domain":
                    self.domain = dns.name.from_text(tokens[1])
                    # domain and search are exclusive
                    self.search = []
                elif tokens[0] == "search":
                    # the last search wins
                    self.search = []
                    for suffix in tokens[1:]:
                        self.search.append(dns.name.from_text(suffix))
                    # We don't set domain as it is not used if
                    # len(self.search) > 0
                elif tokens[0] == "options":
                    for opt in tokens[1:]:
                        if opt == "rotate":
                            self.rotate = True
                        elif opt == "edns0":
                            self.use_edns()
                        elif "timeout" in opt:
                            try:
                                self.timeout = int(opt.split(":")[1])
                            except (ValueError, IndexError):
                                pass
                        elif "ndots" in opt:
                            try:
                                self.ndots = int(opt.split(":")[1])
                            except (ValueError, IndexError):
                                pass
        if len(nameservers) == 0:
>           raise NoResolverConfiguration("no nameservers")
E           dns.resolver.NoResolverConfiguration: no nameservers

/usr/lib/python3/dist-packages/dns/resolver.py:1039: NoResolverConfiguration
------------------------------------------------------------------------------------------------ Captured log call ------------------------------------------------------------------------------------------------
DEBUG    certbot_dns_desec.dns_desec:dns_desec.py:91 Authenticator._cleanup: example.com, _acme-challenge.example.com, Slui_IKoxhFjRRete7mBO4dnCu24lJt4G4q1k-CO1ho
_________________________________________________________________________________________ AuthenticatorTest.test_perform __________________________________________________________________________________________

self = <certbot_dns_desec.dns_desec_test.AuthenticatorTest testMethod=test_perform>, unused_mock_get_utility = <certbot.tests.util.FreezableMock object at 0x7fa8ea4e74d0>

    @test_util.patch_display_util()
    def test_perform(self, unused_mock_get_utility):
>       self.auth.perform([self.achall])

certbot_dns_desec/dns_desec_test.py:54: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
/usr/lib/python3/dist-packages/certbot/plugins/dns_common.py:80: in perform
    self._perform(domain, validation_domain_name, validation)
certbot_dns_desec/dns_desec.py:88: in _perform
    self._desec_work(domain, validation_name, validation, set.union)
certbot_dns_desec/dns_desec.py:72: in _desec_work
    validation_name = dns.resolver.resolve(validation_name, 'CNAME')[0].target
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
/usr/lib/python3/dist-packages/dns/resolver.py:1564: in resolve
    return get_default_resolver().resolve(
           ^^^^^^^^^^^^^^^^^^^^^^
/usr/lib/python3/dist-packages/dns/resolver.py:1528: in get_default_resolver
    reset_default_resolver()
/usr/lib/python3/dist-packages/dns/resolver.py:1541: in reset_default_resolver
    default_resolver = Resolver()
                       ^^^^^^^^^^
/usr/lib/python3/dist-packages/dns/resolver.py:945: in __init__
    self.read_resolv_conf(filename)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <dns.resolver.Resolver object at 0x7fa8ea90f4d0>, f = <_io.TextIOWrapper name='/etc/resolv.conf' mode='r' encoding='utf-8'>

    def read_resolv_conf(self, f: Any) -> None:
        """Process *f* as a file in the /etc/resolv.conf format.  If f is
        a ``str``, it is used as the name of the file to open; otherwise it
        is treated as the file itself.
    
        Interprets the following items:
    
        - nameserver - name server IP address
    
        - domain - local domain name
    
        - search - search list for host-name lookup
    
        - options - supported options are rotate, timeout, edns0, and ndots
    
        """
    
        nameservers = []
        if isinstance(f, str):
            try:
                cm: contextlib.AbstractContextManager = open(f)
            except OSError:
                # /etc/resolv.conf doesn't exist, can't be read, etc.
                raise NoResolverConfiguration(f"cannot open {f}")
        else:
            cm = contextlib.nullcontext(f)
        with cm as f:
            for l in f:
                if len(l) == 0 or l[0] == "#" or l[0] == ";":
                    continue
                tokens = l.split()
    
                # Any line containing less than 2 tokens is malformed
                if len(tokens) < 2:
                    continue
    
                if tokens[0] == "nameserver":
                    nameservers.append(tokens[1])
                elif tokens[0] == "domain":
                    self.domain = dns.name.from_text(tokens[1])
                    # domain and search are exclusive
                    self.search = []
                elif tokens[0] == "search":
                    # the last search wins
                    self.search = []
                    for suffix in tokens[1:]:
                        self.search.append(dns.name.from_text(suffix))
                    # We don't set domain as it is not used if
                    # len(self.search) > 0
                elif tokens[0] == "options":
                    for opt in tokens[1:]:
                        if opt == "rotate":
                            self.rotate = True
                        elif opt == "edns0":
                            self.use_edns()
                        elif "timeout" in opt:
                            try:
                                self.timeout = int(opt.split(":")[1])
                            except (ValueError, IndexError):
                                pass
                        elif "ndots" in opt:
                            try:
                                self.ndots = int(opt.split(":")[1])
                            except (ValueError, IndexError):
                                pass
        if len(nameservers) == 0:
>           raise NoResolverConfiguration("no nameservers")
E           dns.resolver.NoResolverConfiguration: no nameservers

/usr/lib/python3/dist-packages/dns/resolver.py:1039: NoResolverConfiguration
------------------------------------------------------------------------------------------------ Captured log call ------------------------------------------------------------------------------------------------
DEBUG    certbot_dns_desec.dns_desec:dns_desec.py:87 Authenticator._perform: example.com, _acme-challenge.example.com, Slui_IKoxhFjRRete7mBO4dnCu24lJt4G4q1k-CO1ho
============================================================================================= short test summary info =============================================================================================
FAILED certbot_dns_desec/dns_desec_test.py::AuthenticatorTest::test_cleanup - dns.resolver.NoResolverConfiguration: no nameservers
FAILED certbot_dns_desec/dns_desec_test.py::AuthenticatorTest::test_perform - dns.resolver.NoResolverConfiguration: no nameservers
========================================================================================== 2 failed, 10 passed in 0.24s ===========================================================================================
E: pybuild pybuild:389: test: plugin distutils failed with: exit code=1: cd /build/python-certbot-dns-desec-1.3.2/.pybuild/cpython3_3.13_certbot-dns-desec/build; python3.13 -m pytest 
dh_auto_test: error: pybuild --test --test-pytest -i python{version} -p 3.13 --test-pytest returned exit code 13
…
```

The patch I'm proposing just adds an exception to the list of accepted exception for this case (which are either `NXDOMAIN` or `NoAnswer`, so the new exception is not fundamentally different).

I've integrated this patch as part of the 1.3.2-1 Debian (sid) upload