### PR TITLE
Drop setuptools from install_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,6 @@ version = "1.3.2"
 install_requires = [
     "certbot",
     "dnspython",
-    "setuptools",
     "requests",
 ]
 


### PR DESCRIPTION
Nothing from setuptools is needed at runtime, and executing setup.py requires that it is installed at builld-time anyway.

See the release-critical bug filed in Debian: https://bugs.debian.org/1125844