### PR TITLE
drop depedency on old external "mock" module

### DIFF
--- a/certbot_dns_desec/dns_desec_test.py
+++ b/certbot_dns_desec/dns_desec_test.py
@@ -2,9 +2,9 @@
 
 import json
 import unittest
+import unittest.mock as mock
 from unittest.mock import patch
 
-import mock
 import requests_mock
 from certbot import errors
 from certbot.compat import os

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 flake8
-mock
 requests-mock


### PR DESCRIPTION
mock is now part of the Python standard library, available as [unittest.mock](https://docs.python.org/dev/library/unittest.mock.html) in Python 3.3 onwards.

https://github.com/testing-cabal/mock